### PR TITLE
Fixed scheduler config name

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/validation/config/DgcConfigProperties.java
+++ b/src/main/java/eu/europa/ec/dgc/validation/config/DgcConfigProperties.java
@@ -39,7 +39,7 @@ public class DgcConfigProperties {
 
     private final GatewayDownload valueSetsDownload = new GatewayDownload();
 
-    private final GatewayDownload countryListDownload = new GatewayDownload();
+    private final GatewayDownload certificatesDownloader = new GatewayDownload();
 
     @Getter
     @Setter


### PR DESCRIPTION
Fixes the config name of the certificates download scheduler, so that the download is performed.